### PR TITLE
CrashpodBalance

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -1,46 +1,35 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/plating)
 "ab" = (
-/turf/simulated/wall/r_wall,
-/area/map_template/crashed_pod)
+/turf/simulated/wall/r_wall)
 "ac" = (
 /obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/plating)
 "ad" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/wall_frame,
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced/full,
-/obj/effect/submap_landmark/joinable_submap/crashed_pod,
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/plating)
 "ae" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/wall_frame,
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced/full,
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/plating)
 "af" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
 	dir = 6
 	},
-/turf/simulated/wall/r_wall,
-/area/map_template/crashed_pod)
+/turf/simulated/wall/r_wall)
 "ag" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/wall_frame,
@@ -49,43 +38,37 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/plating)
 "ah" = (
 /obj/machinery/alarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "ai" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/raisins,
 /obj/item/weapon/reagent_containers/food/drinks/glass2/fitnessflask,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "aj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "ak" = (
 /obj/machinery/power/terminal,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "al" = (
 /obj/structure/sign/kiddieplaque{
 	desc = "A plaque with information regarding this particular lifepod. It reads: 'Armalev Industries Skyfin-E, Exoplanetary Suvival Pod' there's a registry number, and an assigned mothership, but they've both been scratched to illegiblity.";
@@ -98,32 +81,26 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "am" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "an" = (
 /obj/machinery/atmospherics/omni/filter,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "ao" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/tastybread,
 /obj/item/weapon/reagent_containers/food/drinks/cans/speer,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "ap" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -137,8 +114,7 @@
 	pixel_x = 27
 	},
 /obj/item/weapon/stock_parts/circuitboard/solar_control,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "aq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -146,8 +122,7 @@
 /obj/structure/closet/hydrant{
 	pixel_x = -27
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "ar" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/cable{
@@ -157,26 +132,22 @@
 	},
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "as" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/power/apc{
-	dir = 2;
 	locked = 0;
 	name = "south bump";
-	operating = 1;
 	pixel_y = -28
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "at" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -188,82 +159,66 @@
 	inputting = 1;
 	outputting = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "au" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	icon_state = "map";
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "av" = (
 /obj/machinery/atmospherics/omni/filter,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "ax" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/plating)
 "ay" = (
-/turf/simulated/wall,
-/area/map_template/crashed_pod)
+/turf/simulated/wall)
 "az" = (
 /obj/machinery/atmospherics/binary/pump,
-/turf/simulated/wall,
-/area/map_template/crashed_pod)
+/turf/simulated/wall)
 "aA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "aB" = (
 /obj/machinery/sleeper{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "aC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering,
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "aD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
 	dir = 5
 	},
-/turf/simulated/wall,
-/area/map_template/crashed_pod)
+/turf/simulated/wall)
 "aE" = (
 /obj/machinery/sleeper{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "aF" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -275,8 +230,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "aG" = (
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/industrial/hatch/orange,
@@ -311,22 +265,19 @@
 /obj/item/stack/material/sandstone{
 	amount = 50
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aI" = (
 /obj/machinery/atmospherics/unary/tank/air,
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -334,12 +285,9 @@
 /obj/structure/curtain/open/shower/engineering,
 /obj/structure/hygiene/shower{
 	dir = 8;
-	icon_state = "shower";
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "aK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -356,26 +304,22 @@
 /obj/item/trash/liquidfood,
 /obj/item/weapon/storage/box/detergent,
 /obj/item/clothing/mask/plunger,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aL" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "aM" = (
 /obj/machinery/pipedispenser,
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "aN" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -385,16 +329,13 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	icon_state = "map_universal";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -403,37 +344,30 @@
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aR" = (
 /obj/machinery/fabricator,
 /obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "aS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/civilian,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/tastybread,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/machinery/light/small{
@@ -441,41 +375,35 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aV" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aW" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aX" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/civilian,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "aZ" = (
-/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
 /obj/structure/bed/chair/shuttle/black,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -485,25 +413,20 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark/monotile)
 "ba" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bb" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/plating)
 "bc" = (
-/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
 /obj/structure/bed/chair/shuttle/black,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark/monotile)
 "bd" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/radio,
@@ -513,8 +436,7 @@
 /obj/item/device/radio,
 /obj/random/plushie,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark/monotile)
 "be" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -524,10 +446,8 @@
 	pixel_x = -27
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bf" = (
-/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
 /obj/structure/bed/chair/shuttle/black,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -536,73 +456,62 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark/monotile)
 "bg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bh" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bi" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bj" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/metal,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark/monotile)
 "bk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bm" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/candy/proteinbar,
 /obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bn" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bq" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
@@ -610,13 +519,11 @@
 	},
 /obj/item/weapon/crowbar,
 /obj/item/weapon/crowbar,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "br" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/microwave,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -625,8 +532,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bu" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/reagent_containers/food/condiment/small/saltshaker,
@@ -635,8 +541,7 @@
 /obj/item/trash/candy/proteinbar,
 /obj/machinery/reagentgrinder,
 /obj/item/weapon/reagent_containers/food/condiment/small/sugar,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -644,33 +549,28 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bx" = (
 /obj/machinery/alarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "by" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -678,22 +578,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/engineering,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -704,12 +601,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bD" = (
 /obj/effect/floor_decal/industrial/hatch/orange,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -719,15 +614,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -737,12 +630,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bH" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "bI" = (
 /obj/structure/closet/crate,
 /obj/item/weapon/storage/briefcase/inflatable,
@@ -754,28 +645,24 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bJ" = (
 /obj/machinery/door/airlock/external{
 	name = "escape pod airlock"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bK" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/ash,
 /obj/item/trash/cigbutt/cigarbutt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bL" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "bM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -805,12 +692,10 @@
 /obj/item/clothing/under/color/blackjumpshorts,
 /obj/item/clothing/under/color/black,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bN" = (
 /obj/machinery/seed_extractor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "bO" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/table/steel_reinforced,
@@ -819,12 +704,10 @@
 /obj/item/trash/candy/proteinbar,
 /obj/item/weapon/reagent_containers/food/drinks/cans/speer,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bP" = (
 /obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "bQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -853,8 +736,7 @@
 /obj/item/clothing/under/color/blackjumpshorts,
 /obj/item/clothing/under/color/black,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bR" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -862,8 +744,7 @@
 /obj/item/device/geiger,
 /obj/item/device/geiger,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bS" = (
 /obj/effect/floor_decal/industrial/hatch/orange,
 /obj/structure/table/rack,
@@ -873,15 +754,13 @@
 /obj/item/clothing/suit/space/emergency,
 /obj/item/weapon/tank/emergency/oxygen/double,
 /obj/item/weapon/tank/emergency/oxygen/double,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "bT" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small,
 /obj/item/weapon/crowbar,
 /obj/item/weapon/crowbar,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -907,8 +786,7 @@
 /obj/item/clothing/under/color/blackjumpshorts,
 /obj/item/clothing/under/color/black,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "bV" = (
 /obj/effect/floor_decal/industrial/hatch/orange,
 /obj/structure/table/rack,
@@ -921,8 +799,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "bW" = (
 /obj/structure/closet/crate/medical,
 /obj/random/firstaid,
@@ -939,8 +816,7 @@
 /obj/item/weapon/storage/med_pouch/radiation,
 /obj/item/weapon/storage/med_pouch/radiation,
 /obj/item/weapon/storage/pill_bottle/assorted,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "bX" = (
 /obj/structure/closet/crate,
 /obj/random/handgun,
@@ -964,8 +840,9 @@
 /obj/random/toolbox,
 /obj/random/toolbox,
 /obj/random/toolbox,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/obj/item/stack/material/aluminium/fifty,
+/obj/item/stack/material/plastic/fifty,
+/turf/simulated/floor/tiled/techfloor/grid)
 "bY" = (
 /obj/structure/closet/crate/freezer/rations,
 /obj/item/weapon/storage/bag/trash,
@@ -992,16 +869,14 @@
 /obj/item/weapon/reagent_containers/food/snacks/liquidfood,
 /obj/item/weapon/reagent_containers/food/snacks/liquidfood,
 /obj/item/weapon/reagent_containers/food/snacks/liquidfood,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
 "bZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/machinery/power/port_gen/pacman/super,
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "ca" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/storage/backpack/dufflebag/eng,
@@ -1010,8 +885,7 @@
 /obj/item/weapon/reagent_containers/food/drinks/cans/speer,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/pen,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/dark)
 "cb" = (
 /obj/item/device/oxycandle,
 /obj/item/device/oxycandle,
@@ -1036,8 +910,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor)
 "cc" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/multitool,
@@ -1057,8 +930,8 @@
 /obj/item/weapon/pen/blue,
 /obj/item/weapon/pen/green,
 /obj/item/weapon/pen/red,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/obj/item/weapon/storage/belt/utility/full,
+/turf/simulated/floor/tiled/techfloor/grid)
 "cd" = (
 /obj/structure/closet/crate/large/hydroponics,
 /obj/item/seeds/potatoseed,
@@ -1081,8 +954,10 @@
 /obj/item/seeds/whitebeetseed,
 /obj/item/weapon/storage/plants,
 /obj/item/seeds/bananaseed,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
+/turf/simulated/floor/tiled/techfloor/grid)
+"QI" = (
+/obj/structure/hygiene/sink/kitchen,
+/turf/simulated/wall/r_wall)
 
 (1,1,1) = {"
 aa
@@ -1122,7 +997,7 @@ ab
 "}
 (3,1,1) = {"
 ac
-ad
+ae
 ah
 aq
 aA
@@ -1266,7 +1141,7 @@ ax
 "}
 (11,1,1) = {"
 ab
-ab
+QI
 ap
 aJ
 ay


### PR DESCRIPTION
Добавил стаки пластика и алюминия на крашпод, которых беегении до сих пор не добавили с появлением новых материалов.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->